### PR TITLE
Fixed some (3) errors

### DIFF
--- a/Verilog/source/SPI_Slave.v
+++ b/Verilog/source/SPI_Slave.v
@@ -33,10 +33,10 @@ module SPI_Slave
    input  [7:0]     i_TX_Byte,  // Byte to serialize to MISO.
 
    // SPI Interface
-   input      i_SPI_Clk,
-   output reg o_SPI_MISO,
-   input      i_SPI_MOSI,
-   input      i_SPI_CS_n
+   input  wire i_SPI_Clk,
+   output wire o_SPI_MISO,
+   input  wire i_SPI_MOSI,
+   input  wire i_SPI_CS_n
    );
 
 
@@ -135,7 +135,7 @@ module SPI_Slave
 
   // Control preload signal.  Should be 1 when CS is high, but as soon as
   // first clock edge is seen it goes low.
-  always @(posedge w_SPI_CLK or posedge i_SPI_CS_n)
+  always @(posedge w_SPI_Clk or posedge i_SPI_CS_n)
   begin
     if (i_SPI_CS_n)
     begin
@@ -154,6 +154,7 @@ module SPI_Slave
   always @(posedge w_SPI_Clk or posedge i_SPI_CS_n)
   begin
     if (i_SPI_CS_n)
+    begin
       r_TX_Bit_Count <= 3'b111;  // Send MSb first
       r_SPI_MISO_Bit <= r_TX_Byte[3'b111];  // Reset to MSb
     end


### PR DESCRIPTION
Changed "o_SPI_MISO" from register to net (line 37) due to combinatorical assignment (line 195).
Fixed typo in sensitivity list (line 138), from w_SPI_CLK to w_SPI_Clk.
Synthesis error: Added begin statement after if block (line 157).